### PR TITLE
Save map position on quit

### DIFF
--- a/kismon/core.py
+++ b/kismon/core.py
@@ -279,6 +279,11 @@ Last seen: %s"""
 		
 	def quit(self):
 		self.clients_stop()
+
+		lat = self.map.osm.get_property("latitude")
+		lon = self.map.osm.get_property("longitude")
+		self.config["map"]["last_position"] = "%.6f/%.6f" % (lat, lon)
+
 		while None in self.config['kismet']['servers']:
 			self.config['kismet']['servers'].remove(None)
 		self.config_handler.write()


### PR DESCRIPTION
Hi,

Default map position is 0/0. I have got over 2000 networks in networks.json without access to kismet server, so every time i need move map to position 50/20 (Poland).

I decided to add new feature "save map position on quit". It is very helpful for me.

What do you think about that?
