### PR TITLE
New feature - Cache map tiles

### DIFF
--- a/kismon/core.py
+++ b/kismon/core.py
@@ -32,6 +32,11 @@ import os
 import sys
 import subprocess
 
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from gi.repository import GLib
+
 try:
 	from .client import *
 	from .gui import MainWindow
@@ -45,13 +50,10 @@ except SystemError:
 	from networks import Networks
 	import utils
 
-import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk
-from gi.repository import GLib
 
 def check_osmgpsmap():
 	try:
+		gi.require_version('OsmGpsMap', '1.0')
 		from gi.repository import OsmGpsMap
 	except:
 		return sys.exc_info()[1]

--- a/kismon/map.py
+++ b/kismon/map.py
@@ -28,11 +28,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 """
 import gi
-gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gdk, GdkPixbuf
 from gi.repository import GObject
-gi.require_version('OsmGpsMap', '1.0')
 from gi.repository import OsmGpsMap
 import cairo
 import io


### PR DESCRIPTION
Hi,

I created feature 'Cache map tiles'. Option is very usefull if you do not have internet access. In simple way you can pre-download map (pre caching). Feature is located in 'View -> Cache map tiles'.

---

By the way, i removed warnings:

> /kismon/windows/channel.py:1: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
>   from gi.repository import Gtk
> /kismon/kismon/core.py:55: PyGIWarning: OsmGpsMap was imported without specifying a version first. Use gi.require_version('OsmGpsMap', '1.0') before import to ensure that the right version gets loaded.

Thank you
